### PR TITLE
use new version of samurai (allowing 602 move array in oware)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat50"
+version := "10.2.1-pstrat51"
 
 scalaVersion := "2.13.5"
 
@@ -16,7 +16,7 @@ libraryDependencies ++= List(
   "joda-time"               % "joda-time"                % "2.10.10",
   "org.typelevel"          %% "cats-core"                % "2.2.0",
   "org.playstrategy"        % "fairystockfish"           % fairystockfishVersion,
-  "com.joansala.aalina"     % "aalina"                   % "2.1.0-pstrat1"
+  "com.joansala.aalina"     % "aalina"                   % "2.1.0-pstrat2"
 )
 
 // Explicitly add in the linux-class path

--- a/src/main/scala/mancala/Api.scala
+++ b/src/main/scala/mancala/Api.scala
@@ -54,11 +54,8 @@ object Api {
     //       at the moment
     val variant = Variant.byKey("oware")
 
-    private val maxPlies = 600 // this is duplicate from format/pgn/Binary and hard coded in lila
-
     def makeMovesWithPrevious(movesList: List[Int], previousMoves: List[String]): Position = {
       val game = new OwareGame()
-      game.ensureCapacity(maxPlies)
       previousMoves.foreach(uci => game.makeMove(uciToMove(uci)))
 
       movesList.map { move =>


### PR DESCRIPTION
use new version of samurai (allowing 602 move array) to fix oware long game issues