### PR TITLE
Fixing a minor precedence issue.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat71"
+version := "10.2.1-pstrat72"
 
 scalaVersion := "2.13.5"
 

--- a/src/main/scala/format/Uci.scala
+++ b/src/main/scala/format/Uci.scala
@@ -401,6 +401,6 @@ object Uci {
          case Uci.FairySFDrop(_)  => s"2_${gf.id}_"
          case Uci.MancalaMove(_)  => s"3_${gf.id}_"
        }
-     } else "") + moves.map(_.piotr) mkString " "
+     } else "") + (moves.map(_.piotr) mkString " ")
 
 }


### PR DESCRIPTION
This stems from this behavior below:
```
scala> ("list") + List("1", "2") mkString " "
val res1: String = l i s t L i s t ( 1 ,   2 )

scala> ("list") + (List("1", "2") mkString " ")
val res2: String = list1 2
```

The first example initial creates a string by calling "toString" on the list, which results in: `"listList(1, 2)"` and then the `mkString` is called on that string, which adds a space in between each of the characters, resulting in: `" l i s t L i s t ( 1 ,   2 )"`