### PR TITLE
Small backend changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat181-dameo3"
+version := "10.2.1-pstrat181-dameo4"
 
 scalaVersion := "2.13.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat181-dameo2"
+version := "10.2.1-pstrat181-dameo3"
 
 scalaVersion := "2.13.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat181-dameo1"
+version := "10.2.1-pstrat181-dameo2"
 
 scalaVersion := "2.13.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "strategygames"
 
 organization := "org.playstrategy"
 
-version := "10.2.1-pstrat181-dameo4"
+version := "10.2.1-pstrat181-dameo5"
 
 scalaVersion := "2.13.10"
 

--- a/src/main/scala/dameo/Actor.scala
+++ b/src/main/scala/dameo/Actor.scala
@@ -22,12 +22,12 @@ final case class Actor(
     def dxs: List[Int] = List(-1, 0, 1)
 
     def posits: List[Pos] = piece.role match {
-      case Man  =>
+      case Man | ActiveMan =>
         dxs
           .flatMap(dx => linearStep(Some(pos), dx, dy))
           .filter(board.withinBounds)
           .filter(board.empty)
-      case King =>
+      case King | ActiveKing =>
         dxs
           .flatMap(dx =>
             dxs.flatMap(dy =>

--- a/src/main/scala/dameo/Actor.scala
+++ b/src/main/scala/dameo/Actor.scala
@@ -14,6 +14,8 @@ final case class Actor(
   lazy val captures: List[Move]                   = capturesWithLineval._1
   lazy val capturesWithLineval: (List[Move], Int) = captureMoves()
   def getCaptures()                               = captures
+  lazy val captureLength: Int                     = capturesWithLineval._2
+
 
   private def noncaptureMoves(): List[Move] = {
     def dy: Int        = if (player == P1) 1 else -1

--- a/src/main/scala/dameo/Board.scala
+++ b/src/main/scala/dameo/Board.scala
@@ -52,6 +52,8 @@ case class Board(
     !pieces.contains(pos)
   }
 
+  def actorAt(at: Pos): Option[Actor] = actors get at
+
   def withHistory(h: History): Board       = copy(history = h)
   def updateHistory(f: History => History) = copy(history = f(history))
 

--- a/src/main/scala/dameo/Replay.scala
+++ b/src/main/scala/dameo/Replay.scala
@@ -66,53 +66,6 @@ object Replay {
     case _                  => sys.error(s"Invalid dameo action $action")
   }
 
-  def replayMove(
-      before: Game,
-      orig: Pos,
-      dest: Pos,
-      boardAfter: Board,
-      promotion: Boolean,
-      endTurn: Boolean
-  ): Move = {
-    def piece: Piece = before.situation.board.pieces(orig)
-
-    def capturePos(pos: Pos, dx: Int, dy: Int): Option[Pos] = {
-      pos
-        .step(dx, dy)
-        .flatMap(stepPos =>
-          if (stepPos == dest || !before.situation.board.pieces.get(stepPos).isEmpty) {
-            Some(stepPos)
-          } else {
-            capturePos(stepPos, dx, dy)
-          }
-        )
-    }
-
-    def capture: Option[Pos] =
-      if (orig.onSameLine(dest)) {
-        def dx: Int = (dest.file.index - orig.file.index).sign
-        def dy: Int = (dest.rank.index - orig.rank.index).sign
-        capturePos(orig, dx, dy).flatMap(capPos =>
-          if (before.situation.board.pieces.get(capPos).map(_.player) == Some(!piece.player)) {
-            Some(capPos)
-          } else {
-            None
-          }
-        )
-      } else { None }
-
-    Move(
-      piece = piece,
-      orig = orig,
-      dest = dest,
-      situationBefore = before.situation,
-      after = boardAfter,
-      autoEndTurn = endTurn,
-      capture = capture,
-      promotion = if (promotion) Some(King) else None
-    )
-  }
-
   private def gameWithActionWhileValid(
       actionStrs: ActionStrs,
       initialFen: FEN,
@@ -124,22 +77,16 @@ object Replay {
 
     def replayMoveFromUci(
         orig: Option[Pos],
-        dest: Option[Pos],
-        promotion: Boolean,
-        endTurn: Boolean
+        dest: Option[Pos]
     ): (Game, Move) =
       (orig, dest) match {
         case (Some(orig), Some(dest)) => {
           state.situation.board.move(orig, dest) match {
-            case Some(boardAfter) => {
-              val move = replayMove(
-                state,
-                orig,
-                dest,
-                boardAfter,
-                promotion,
-                endTurn
-              )
+            case Some(_) => {
+              val actor = state.situation.board.actors(orig)
+              val actorMoves = actor.captures ++ actor.noncaptures
+              val move = actorMoves.find(_.dest == dest).get
+
               state = state(move)
               (state, move)
             }
@@ -159,15 +106,13 @@ object Replay {
 
     val gameWithActions: List[(Game, Move)] =
       actionStrs.flatMap { turnStrs =>
-        turnStrs.zipWithIndex.map {
-          case (uci, i) => {
+        turnStrs.map {
+          case uci => {
             uci match {
-              case Uci.Move.moveR(orig, dest, promotion) =>
+              case Uci.Move.moveR(orig, dest, _) =>
                 replayMoveFromUci(
                   Pos.fromKey(orig),
-                  Pos.fromKey(dest),
-                  promotion == "K",
-                  endTurn = i + 1 == turnStrs.length
+                  Pos.fromKey(dest)
                 )
               case (action: String)                      =>
                 sys.error(s"Invalid action for replay: $action")

--- a/src/main/scala/dameo/Replay.scala
+++ b/src/main/scala/dameo/Replay.scala
@@ -85,10 +85,17 @@ object Replay {
             case Some(_) => {
               val actor = state.situation.board.actors(orig)
               val actorMoves = actor.captures ++ actor.noncaptures
-              val move = actorMoves.find(_.dest == dest).get
-
-              state = state(move)
-              (state, move)
+              actorMoves.find(_.dest == dest) match {
+                case Some(move) => {
+                  state = state(move)
+                  (state, move)
+                }
+                case _          => {
+                  val uciMove = s"${orig}${dest}"
+                  errors += uciMove + ","
+                  sys.error(s"Invalid move for replay: ${uciMove}")
+                }
+              }
             }
             case _                => {
               val uciMove = s"${orig}${dest}"

--- a/src/main/scala/dameo/Situation.scala
+++ b/src/main/scala/dameo/Situation.scala
@@ -37,6 +37,16 @@ case class Situation(board: Board, player: Player) {
     else if (autoDraw) Some(Status.Draw)
     else None
 
+  lazy val allMovesCaptureLength: Int =
+    actors.foldLeft(0) { case (max, actor) =>
+      Math.max(actor.captureLength, max)
+    }
+
+  def captureLengthFrom(pos: Pos): Option[Int] =
+    actorAt(pos).map(_.captureLength)
+
+  def actorAt(pos: Pos): Option[Actor] = board.actorAt(pos)
+
   def move(
       from: Pos,
       to: Pos,

--- a/src/main/scala/dameo/format/Forsyth.scala
+++ b/src/main/scala/dameo/format/Forsyth.scala
@@ -103,7 +103,7 @@ object Forsyth {
           )
           .mkString(",")
       )
-    s"W${pieces(P1)}:B${pieces(P2)}"
+    s"W${pieces.getOrElse(P1, "")}:B${pieces.getOrElse(P2, "")}"
   }
 
   def boardAndPlayer(situation: Situation): String =

--- a/src/test/scala/dameo/DameoReplayTest.scala
+++ b/src/test/scala/dameo/DameoReplayTest.scala
@@ -88,15 +88,11 @@ class DameoReplayTest extends DameoTest with ValidatedMatchers {
 
     "multi-move capture turn" should {
       /* Test for a problematic situation encountered during front-end implementation.
-      After moves:
+      After these moves:
         d3d4
         d6d5
         d4d6
-      the current turn should be W, and the turnCount should be 2. However in the bugged
-      situation they were resp. B and 3.
-      In the problematic situation, Forsyth.>> is called from StepBuilder.scala in the lila repo.
-      Forsyth.>> is called from a list returned by Replay.gameWithUciWhileValid, though, so
-      that is where the error may be.
+      the current turn should be W, and the turnCount should be 2.
       */
       val vectorActionStrs = Vector(
         Vector("d3d4"),

--- a/src/test/scala/dameo/DameoReplayTest.scala
+++ b/src/test/scala/dameo/DameoReplayTest.scala
@@ -86,6 +86,44 @@ class DameoReplayTest extends DameoTest with ValidatedMatchers {
       }
     }
 
+    "multi-move capture turn" should {
+      /* Test for a problematic situation encountered during front-end implementation.
+      After moves:
+        d3d4
+        d6d5
+        d4d6
+      the current turn should be W, and the turnCount should be 2. However in the bugged
+      situation they were resp. B and 3.
+      In the problematic situation, Forsyth.>> is called from StepBuilder.scala in the lila repo.
+      Forsyth.>> is called from a list returned by Replay.gameWithUciWhileValid, though, so
+      that is where the error may be.
+      */
+      val vectorActionStrs = Vector(
+        Vector("d3d4"),
+        Vector("d6d5"),
+        Vector("d4d6")
+      )
+      playActionStrs(vectorActionStrs.flatten.toList) must beValid.like { g =>
+        val replay = Replay
+          .gameWithUciWhileValid(
+            vectorActionStrs,
+            Dameo.initialFen,
+            Dameo
+          )
+          ._2
+          .reverse
+          .head
+          ._1
+        g.plies must_== replay.plies
+        g.turnCount must_== replay.turnCount
+        g.startedAtPly must_== replay.startedAtPly
+        g.startedAtTurn must_== replay.startedAtTurn
+        g.actionStrs must_== replay.actionStrs
+        g.situation.board.pieces must_== replay.situation.board.pieces
+        g.situation.board.history.lastTurn must_== replay.situation.board.history.lastTurn
+        g.situation.board.history.currentTurn must_== replay.situation.board.history.currentTurn
+        g.situation.board.variant must_== replay.situation.board.variant
+      }
+    }
   }
-
 }

--- a/src/test/scala/dameo/DameoSituationTest.scala
+++ b/src/test/scala/dameo/DameoSituationTest.scala
@@ -1,0 +1,34 @@
+package strategygames.dameo
+
+import org.specs2.matcher.ValidatedMatchers
+import strategygames.dameo.format.FEN
+
+class DameoSituationTest extends DameoTest with ValidatedMatchers {
+  "situation" should {
+    "Report the captureLength for all pieces" in {
+      // As used in lila/Event.scala
+      val board      = Board(FEN("W:WKc6,d5,f5,f7,g8:Bd4,f4:H0:F1").pieces, variant.Dameo)
+      val situation = Situation(board, P2)
+      situation.allMovesCaptureLength must_== 3
+    }
+  
+    "Report the captureLength for all pieces including kings" in {
+      val board      = Board(FEN("W:WKc6,d5,f5,f7,g8:Bd4,Kf3:H0:F1").pieces, variant.Dameo)
+      val situation = Situation(board, P2)
+      situation.allMovesCaptureLength must_== 3
+    }
+
+    "Report the captureLength for a single (active) piece" in {
+      val board      = Board(FEN("W:WKc6,d5,Gf5,Gf7,g8:Bd4,Af8:H0:F1").pieces, variant.Dameo)
+      val situation = Situation(board, P2)
+      situation.captureLengthFrom(Pos.F8) must_== Some(1)
+    }
+
+    "Report the captureLength for a single (active) king" in {
+      val board      = Board(FEN("W:WKc6,c8,d5,Gf5,Gf7:Bd4,Bf8:H0:F1").pieces, variant.Dameo)
+      val situation = Situation(board, P2)
+      situation.captureLengthFrom(Pos.F8) must_== Some(1)
+    }
+  
+  }
+}


### PR DESCRIPTION
Two issues that I encountered while working on the frontend:

1. **Use Actor moves in Replay**
There was still some duplicate (and incorrect) game logic in Replay, I've switched it over to using the Actor moves, including a test for the bug I encountered.

2. **Get the captureLength from Situation**
Either for a single piece, or the maximum over all pieces. This will be used in Lila, to pass the current capturelength to the frontend, just like in draughts.